### PR TITLE
Update docker-compose command to new syntax

### DIFF
--- a/.github/workflows/CICD Microservices.yaml
+++ b/.github/workflows/CICD Microservices.yaml
@@ -52,4 +52,4 @@ jobs:
           docker pull ghcr.io/hsm-sanosoft/${{vars.MICROSERVICE_NAME}}:latest
 
           echo "Restarting ${{vars.MICROSERVICE_NAME}} container..."
-          docker-compose -f docker-compose.prod.yml up -d --no-deps ${{vars.MICROSERVICE_NAME}}
+          docker compose -f docker-compose.prod.yml up -d --no-deps ${{vars.MICROSERVICE_NAME}}


### PR DESCRIPTION
Replace the deprecated `docker-compose` command with the updated `docker compose` syntax for improved compatibility.